### PR TITLE
Add custom unbound config support

### DIFF
--- a/one-container/README.md
+++ b/one-container/README.md
@@ -38,7 +38,7 @@ REV_SERVER_TARGET=192.168.1.1
 REV_SERVER_CIDR=192.168.0.0/16
 HOSTNAME=pihole
 DOMAIN_NAME=pihole.local
-HOST_PATH=./opt-unbound/:/opt/unbound/
+UNBOUND_CONFIG_MOUNT=./opt-unbound/:/opt/unbound/
 ```
 
 ### Using Portainer stacks?

--- a/one-container/README.md
+++ b/one-container/README.md
@@ -8,9 +8,9 @@ The base image for the container is the [official Pi-Hole container](https://hub
 
 ## Usage
 
-First create a `.env` file to substitute variables for your deployment. 
+First create a `.env` file to substitute variables for your deployment.
 
-
+Then create a folder on the host machine where you want to store your unbound config. Copy the unbound-pihole.conf file into this folder and make your changes. 
 ### Required environment variables
 
 > Vars and descriptions replicated from the [official pihole container](https://github.com/pi-hole/docker-pi-hole/):
@@ -24,6 +24,7 @@ First create a `.env` file to substitute variables for your deployment.
 | `REV_SERVER_DOMAIN: <Network Domain>`<br/> | If conditional forwarding is enabled, set the domain of the local network router
 | `REV_SERVER_TARGET: <Router's IP>`<br/> | If conditional forwarding is enabled, set the IP of the local network router
 | `REV_SERVER_CIDR: <Reverse DNS>`<br/>| If conditional forwarding is enabled, set the reverse DNS zone (e.g. `192.168.0.0/24`)
+| `UNBOUND_CONFIG_MOUNT: <Mount unbound config>`<br/>| Volume mount for path on host machine (`eg. './opt-unbound/:/opt/unbound/'. You should not change :/opt/unbound/`)
 
 Example `.env` file in the same directory as your `docker-compose.yaml` file:
 
@@ -37,6 +38,7 @@ REV_SERVER_TARGET=192.168.1.1
 REV_SERVER_CIDR=192.168.0.0/16
 HOSTNAME=pihole
 DOMAIN_NAME=pihole.local
+HOST_PATH=./opt-unbound/:/opt/unbound/
 ```
 
 ### Using Portainer stacks?

--- a/one-container/docker-compose.yaml
+++ b/one-container/docker-compose.yaml
@@ -31,6 +31,6 @@ services:
     volumes:
       - etc_pihole-unbound:/etc/pihole:rw
       - etc_pihole_dnsmasq-unbound:/etc/dnsmasq.d:rw
-      - '${HOST_PATH}' # change './opt-unbound/' to your desired path
+      - '${UNBOUND_CONFIG_MOUNT}'
     restart: unless-stopped
 

--- a/one-container/docker-compose.yaml
+++ b/one-container/docker-compose.yaml
@@ -31,5 +31,6 @@ services:
     volumes:
       - etc_pihole-unbound:/etc/pihole:rw
       - etc_pihole_dnsmasq-unbound:/etc/dnsmasq.d:rw
+      - '${HOST_PATH}' # change './opt-unbound/' to your desired path
     restart: unless-stopped
 

--- a/one-container/pihole-unbound/Dockerfile
+++ b/one-container/pihole-unbound/Dockerfile
@@ -2,7 +2,7 @@ FROM pihole/pihole:v5.8.1
 RUN apt update && apt install -y unbound
 
 COPY lighttpd-external.conf /etc/lighttpd/external.conf 
-COPY unbound-pihole.conf /etc/unbound/unbound.conf.d/pi-hole.conf
+RUN echo "include: \"/opt/unbound/*.conf\"" >> /etc/unbound/unbound.conf 
 COPY start_unbound_and_s6_init.sh start_unbound_and_s6_init.sh
 
 RUN chmod +x start_unbound_and_s6_init.sh

--- a/two-container/docker-compose.yaml
+++ b/two-container/docker-compose.yaml
@@ -39,7 +39,7 @@ services:
       - 53/tcp
       - 53/udp
     volumes: 
-      - /volume1/docker/pihole-unbound/unbound/unbound.conf:/opt/unbound/etc/unbound/
+      - /volume1/docker/pihole-unbound/unbound:/opt/unbound/etc/unbound/
     networks:
       home:
         ipv4_address: 192.168.1.6

--- a/two-container/docker-compose.yaml
+++ b/two-container/docker-compose.yaml
@@ -38,6 +38,8 @@ services:
     ports:
       - 53/tcp
       - 53/udp
+    volumes: 
+      - /volume1/docker/pihole-unbound/unbound/unbound.conf:/opt/unbound/etc/unbound/
     networks:
       home:
         ipv4_address: 192.168.1.6


### PR DESCRIPTION
As mentioned here #7, it would be great to be able to change the unbound config without having to rebuild the image. 

For the two container version, I simply added a new volume mount that mapped the unbound configs into containers on the host machine.

For the one container version I had to tell unbound where to find the config in the future and you have to create this path and save the config file there before starting the container.