### PR TITLE
Add github action workflow to trigger daily build with latest image

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,50 @@
+name: Push lastest release to dockerhub
+
+on:
+    # cron job to trigger the build on any push to main
+  push:
+    branches:
+      - 'main'
+  schedule:
+  # cron job to trigger the build dialy
+    - cron:  '0 0 * * *'
+
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: REST API with curl
+      id: STEP_GET_TAG
+      run: |
+        echo "VERSION=$(curl -s https://api.github.com/repos/pi-hole/docker-pi-hole/releases | jq '.[0] | .name' -r)" >> $GITHUB_OUTPUT
+      -  name: Get value
+      run: echo "The selected color is ${{ steps.STEP_GET_TAG.outputs.VERSION }}"
+      # - name: Get latest release of pihole docker
+      #   uses: rez0n/actions-github-release@main
+      #   id: pihole_version
+      #   env:
+      #     token: ${{ secrets.GITHUB_TOKEN }}
+      #     repository: "pi-hole/docker-pi-hole"
+      #     type: "stable"
+      # -
+      #   name: Set up QEMU
+      #   uses: docker/setup-qemu-action@v2
+      # -
+      #   name: Set up Docker Buildx
+      #   uses: docker/setup-buildx-action@v2
+      # -
+      #   name: Login to Docker Hub
+      #   uses: docker/login-action@v2
+      #   with:
+      #     username: ${{ secrets.DOCKER_HUB_USERNAME }}
+      #     password: ${{ secrets.DOCKER_HUB_TOKEN }}
+      # -
+      #   name: Build and push
+      #   uses: docker/build-push-action@v3
+      #   with:
+      #     build-args: PIHOLE_VERSION=${{ steps.pihole_version.outputs.release }}
+      #     context: "{{defaultContext}}:one-container/pihole-unbound/"
+      #     platforms: linux/arm/v7,linux/arm64/v8,linux/amd64
+      #     push: true
+      #     tags: cbcrowe/pihole-unbound:latest,cbcrowe/pihole-unbound:${{ steps.pihole_version.outputs.release }}


### PR DESCRIPTION
### **Let's solve this once and for all**

Just to avoid waiting for days to get the latest updated image I created this git action workflow that allows you to automate the building process and push it to your docker repository. 

This workflow should work out of the box but you need to create two secrets with the following names in your repo (as I don't have access 🙂) 

`DOCKER_HUB_USERNAME` (this should contain your docker hub username)
`DOCKER_HUB_TOKEN` (this contains the docker hub token to push the image and update tags) 

I already tried this in my branch using my credential to my [docker repository](https://hub.docker.com/r/tritethunder/pihole-ubound-test/tags) and it's working fine for me.

I am attaching a screenshot to guide where you need to add secrets. Let me know if you need any help setting this up.

<img width="1260" alt="image" src="https://user-images.githubusercontent.com/555317/195647417-a9a2d33b-eaed-4273-a555-d9c7f08cbe64.png">
