### PR TITLE
Update readme to pihole v6, remove FTLCONF_LOCAL_IPV4

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,24 +32,18 @@ The [example Docker Compose file](example/compose.yaml) demonstrates how this im
 
 ### Configuration Options
 
-You can use all environment variables supported by the official Pi-hole container. Some examples are listed below. Vars and descriptions are replicated from the [official documentation](https://github.com/pi-hole/docker-pi-hole/#environment-variables):
+You can use all environment variables supported by the official Pi-hole container. Some examples are listed below. Vars and descriptions are replicated from the [official documentation](https://github.com/pi-hole/docker-pi-hole/blob/master/README.md#recommended-environment-variables):
 
 | Variable | Default | Value | Description |
 | -------- | ------- | ----- | ---------- |
 | `TZ` | UTC | `<Timezone>` | Set your [timezone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) to make sure logs rotate at local midnight instead of at UTC midnight.
-| `WEBPASSWORD` | random | `<Admin password>` | http://pi.hole/admin password. Run `docker logs pihole \| grep random` to find your random pass.
-| `FTLCONF_LOCAL_IPV4` | unset | `<Host's IP>` | Set to your server's LAN IP, used by web block modes and lighttpd bind address.
-| `REV_SERVER` | `false` | `<"true"\|"false">` | Enable DNS conditional forwarding for device name resolution |
-| `REV_SERVER_DOMAIN` | unset | Network Domain | If conditional forwarding is enabled, set the domain of the local network router |
-| `REV_SERVER_TARGET` | unset | Router's IP | If conditional forwarding is enabled, set the IP of the local network router |
-| `REV_SERVER_CIDR` | unset | Reverse DNS | If conditional forwarding is enabled, set the reverse DNS zone (e.g. `192.168.0.0/24`) |
-| `WEBTHEME` | `default-light` | `<"default-dark"\|"default-darker"\|"default-light"\|"default-auto"\|"lcars">`| User interface theme to use.
-| `WEB_PORT` | 80 | `<Port>` | Listening port for the Pi-hole webserver. |
+| `FTLCONF_webserver_api_password` | random | `<Admin password>` | <http://pi.hole/admin> password.<br>Run `docker logs pihole \| grep random` to find your random password.
+| `FTLCONF_dns_upstreams` | `127.0.0.1#5335` | IPs delimited by `;` | Upstream DNS server(s) for Pi-hole to forward queries to, separated by a semicolon.<br><br>Supports non-standard ports with: `#[port number]`, e.g `127.0.0.1#5053;8.8.8.8;8.8.4.4`.<br><br>Supports [Docker service names and links](https://docs.docker.com/compose/networking/) instead of IPs, e.g `upstream0,upstream1` where `upstream0` and `upstream1` are the service names of or links to docker services.<br><br>**Note:** The existence of this environment variable assumes this as the _sole_ management of upstream DNS. Upstream DNS added via the web interface will be overwritten on container restart/recreation. |
+| `FTLCONF_[SETTING]` | unset | As per documentation | Customize pihole.toml with settings described in the [API Documentation](https://docs.pi-hole.net/api).<br><br>Replace `.` with `_`, e.g for `dns.dnssec=true` use `FTLCONF_dns_dnssec: 'true'`.<br/>Array type configs should be delimited with `;`.|
 
 Alternatively you can use an `.env` file in the same directory as your `compose.yaml` file:
 
 ```
-FTLCONF_LOCAL_IPV4=192.168.1.10
 TZ=America/Los_Angeles
 WEBPASSWORD=ChangeMe!
 REV_SERVER=true

--- a/example/compose.yaml
+++ b/example/compose.yaml
@@ -13,14 +13,9 @@ services:
       # - 5335:5335/tcp # Uncomment to enable unbound access on local server
       # - 22/tcp # Uncomment to enable SSH
     environment:
-      - FTLCONF_LOCAL_IPV4=${FTLCONF_LOCAL_IPV4}
       - TZ=${TZ:-UTC}
       - FTLCONF_webserver_api_password=${WEBPASSWORD}
       - FTLCONF_webserver_interface_theme=${WEBTHEME:-default-light}
-      #- REV_SERVER=${REV_SERVER:-false}
-      #- REV_SERVER_TARGET=${REV_SERVER_TARGET}
-      #- REV_SERVER_DOMAIN=${REV_SERVER_DOMAIN}
-      #- REV_SERVER_CIDR=${REV_SERVER_CIDR}
       - FTLCONF_dns_revServers=${REV_SERVER:-false},${REV_SERVER_CIDR},${REV_SERVER_TARGET},${REV_SERVER_DOMAIN}
       - FTLCONF_dns_upstreams=127.0.0.1#5335
       - FTLCONF_dns_dnssec="true"


### PR DESCRIPTION
The readme environment variable section still had pihole v5 documentation.  I copied over the relevant v6 environment variable section from the official pihole docker repository.  In addition, I noticed FTLCONF_LOCAL_IPV4 was still included in the compose file, however, that env variable was retired with v5, so I removed that as well.