### PR TITLE
fix(example): fix empty env var

### DIFF
--- a/example/compose.yaml
+++ b/example/compose.yaml
@@ -25,7 +25,7 @@ services:
       - FTLCONF_dns_upstreams=127.0.0.1#5335
       - FTLCONF_dns_dnssec="true"
       - FTLCONF_dns_listeningMode=single
-      - FTLCONF_webserver_port=${WEB_PORT}
+      - FTLCONF_webserver_port=${PIHOLE_WEBPORT}
     volumes:
       - etc_pihole-unbound:/etc/pihole:rw
       - etc_pihole_dnsmasq-unbound:/etc/dnsmasq.d:rw


### PR DESCRIPTION
Previously, we had both `PIHOLE_WEBPORT` and `WEB_PORT` in the example `docker-compose.yaml`, which led to the following warning:

```bash
WARN[0000] The "WEB_PORT" variable is not set. Defaulting to a blank string.
WARNING: Environment variable FTLCONF_webserver_port has no value, substituting with empty string
WARNING: Not starting web server as webserver.port is empty. API will not be available!
```

This happens because it can easily go unnoticed that we have two environmental variables for essentially the same thing, so we fix this by keeping one of the two.