### PR TITLE
Update unbound-pihole.conf

### DIFF
--- a/docker/unbound-pihole.conf
+++ b/docker/unbound-pihole.conf
@@ -1,5 +1,3 @@
-# Config pulled from https://docs.pi-hole.net/guides/unbound/
-
 server:
     # If no logfile is specified, syslog is used
     # logfile: "/var/log/unbound/unbound.log"
@@ -11,8 +9,8 @@ server:
     do-udp: yes
     do-tcp: yes
 
-    # May be set to yes if you have IPv6 connectivity
-    do-ip6: no
+    # May be set to no if you don't have IPv6 connectivity
+    do-ip6: yes
 
     # You want to leave this to no unless you have *native* IPv6. With 6to4 and
     # Terredo tunnels your web browser should favor IPv4 for the same reasons
@@ -33,7 +31,20 @@ server:
     use-caps-for-id: no
 
     # Reduce EDNS reassembly buffer size.
-    # Suggested by the unbound man page to reduce fragmentation reassembly problems
+    # IP fragmentation is unreliable on the Internet today, and can cause
+    # transmission failures when large DNS messages are sent via UDP. Even
+    # when fragmentation does work, it may not be secure; it is theoretically
+    # possible to spoof parts of a fragmented DNS message, without easy
+    # detection at the receiving end. Recently, there was an excellent study
+    # >>> Defragmenting DNS - Determining the optimal maximum UDP response size for DNS <<<
+    # by Axel Koolhaas, and Tjeerd Slokker (https://indico.dns-oarc.net/event/36/contributions/776/)
+    # in collaboration with NLnet Labs explored DNS using real world data from the
+    # the RIPE Atlas probes and the researchers suggested different values for
+    # IPv4 and IPv6 and in different scenarios. They advise that servers should
+    # be configured to limit DNS messages sent over UDP to a size that will not
+    # trigger fragmentation on typical network links. DNS servers can switch
+    # from UDP to TCP when a DNS response is too big to fit in this limited
+    # buffer size. This value has also been suggested in DNS Flag Day 2020.
     edns-buffer-size: 1232
 
     # Perform prefetching of close to expired message cache entries
@@ -44,8 +55,7 @@ server:
     num-threads: 1
 
     # Ensure kernel buffer is large enough to not lose messages in traffic spikes
-    # Be aware that if enabled (requires CAP_NET_ADMIN or privileged), the kernel buffer must have the defined amount of memory, if not, a warning will be raised.
-    #so-rcvbuf: 1m
+    so-rcvbuf: 1m
 
     # Ensure privacy of local IP ranges
     private-address: 192.168.0.0/16
@@ -54,3 +64,10 @@ server:
     private-address: 10.0.0.0/8
     private-address: fd00::/8
     private-address: fe80::/10
+
+    # Ensure no reverse queries to non-public IP ranges (RFC6303 4.2)
+    private-address: 192.0.2.0/24
+    private-address: 198.51.100.0/24
+    private-address: 203.0.113.0/24
+    private-address: 255.255.255.255/32
+    private-address: 2001:db8::/32


### PR DESCRIPTION
There had been some changes in the official unbound guide https://docs.pi-hole.net/guides/dns/unbound/, especially do-ip6: yes and disable reverse queries in private network.