### PR TITLE
Using default config as Unbound's entrypoint

### DIFF
--- a/docker/custom-entrypoint.sh
+++ b/docker/custom-entrypoint.sh
@@ -6,7 +6,7 @@ chown pihole:pihole /var/log/unbound
 
 # Start Unbound with error checking
 echo "  [i] Starting Unbound"
-/usr/sbin/unbound -d -c /etc/unbound/unbound.conf.d/pi-hole.conf &
+/usr/sbin/unbound -d -c /etc/unbound/unbound.conf &
 UNBOUND_PID=$!
 
 # Wait briefly and check if Unbound started successfully


### PR DESCRIPTION
Given that loading only the `pi-hole.conf` file can be somewhat inconvenient when changes to the Unbound's configuration files are needed, I propose the following change that leverages the default configuration to load all the `.conf` files found in the `/etc/unbound/unbound.conf.d/` directory.
As a practical example of the convenience of the changes, you can look at the issue #316 

This is just my two cents so, if you have any suggestions, fell free to share them! :D