### PR TITLE
Correct ownership of Unbound log directory

### DIFF
--- a/docker/custom-entrypoint.sh
+++ b/docker/custom-entrypoint.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 
-# Ensure Unbound log directory exists
+# Ensure Unbound log directory exists and has appropriate ownership
 mkdir -p /var/log/unbound
-chown pihole:pihole /var/log/unbound
+chown unbound /var/log/unbound
 
 # Start Unbound with error checking
 echo "  [i] Starting Unbound"


### PR DESCRIPTION
Although this project is configured [not to log to file by default](https://github.com/mpgirro/docker-pihole-unbound/blob/dcef5a362c9521396b09c4c3589c8969e25b1198/docker/unbound-pihole.conf#L5), when I was making some changes locally and trying to debug unbound through logs I was not getting output. It turns out that the `/var/log/unbound` directory is created as owned by `pihole`, and unbound runs with the `unbound` user which does not have write permissions over the directory, so logging will not work. https://docs.pi-hole.net/guides/dns/unbound/#add-logging-to-unbound confirms that the `unbound` user should own this directory:

> Second, create log dir and file, set permissions:
>```bash
>sudo mkdir -p /var/log/unbound
>sudo touch /var/log/unbound/unbound.log
>sudo chown unbound /var/log/unbound/unbound.log
>```

This PR adjusts ownership of that directory. I decided not to `touch` the file like the guide does since, as it stands right now, the project does not log to file by default and I think creating an empty file that is never used may be confusing.
